### PR TITLE
Fix issue #3: Update CI workflow to ensure test-macos runs after test-ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           test -f ~/.p10k.zsh && echo "Powerlevel10k config present ✓"
   
   test-macos:
+    needs: test-ubuntu
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request addresses issue #3 by updating the CI workflow to ensure that the test-macos job only runs after the test-ubuntu job completes successfully.